### PR TITLE
fix push --no-verify message

### DIFF
--- a/index.js
+++ b/index.js
@@ -281,7 +281,7 @@ Hook.log = {
     'hook returned an exit code (%d). If you\'re feeling adventurous you can',
     'skip the git pre-push hooks by adding the following flags to your push:',
     '',
-    '  git push -n (or --no-verify)',
+    '  git push --no-verify',
     '',
     'This is ill-advised since the push is broken.'
   ].join('\n')


### PR DESCRIPTION
-n is an alias for --dry-run in `git push` contrary to `git commit`