### PR TITLE
compatible windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -214,7 +214,9 @@ Hook.prototype.run = function runner() {
     // this doesn't have the required `isAtty` information that libraries use to
     // output colors resulting in script output that doesn't have any color.
     //
-    spawn(hooked.npm, ['run', script, '--silent'], {
+    
+    let cmd = process.platform=='win32' ? 'npm.cmd' : 'npm';
+    spawn(cmd, ['run', script, '--silent'], {
       env: process.env,
       cwd: hooked.root,
       stdio: [0, 1, 2]


### PR DESCRIPTION
fixed error in windows:

```bash
events.js:160
      throw er; // Unhandled 'error' event
      ^

Error: spawn npm ENOENT
    at exports._errnoException (util.js:1022:11)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:193:32)
    at onErrorNT (internal/child_process.js:359:16)
    at _combinedTickCallback (internal/process/next_tick.js:74:11)
    at process._tickCallback (internal/process/next_tick.js:98:9)
    at Module.runMain (module.js:606:11)
    at run (bootstrap_node.js:394:7)
    at startup (bootstrap_node.js:149:9)
    at bootstrap_node.js:509:3
```