### PR TITLE
Fix advice about overriding pre-push hook

### DIFF
--- a/index.js
+++ b/index.js
@@ -283,7 +283,7 @@ Hook.log = {
     'hook returned an exit code (%d). If you\'re feeling adventurous you can',
     'skip the git pre-push hooks by adding the following flags to your push:',
     '',
-    '  git push -n (or --no-verify)',
+    '  git push --no-verify',
     '',
     'This is ill-advised since the push is broken.'
   ].join('\n')


### PR DESCRIPTION
`git push` does not support `-n` as an option.
https://git-scm.com/docs/git-push#git-push---no-verify
`git commit` however does support `-n`, which is where this confusion likely came from.

git push source code:
https://github.com/git/git/blob/12039e008f9a4e3394f3f94f8ea897785cb09448/builtin/push.c#L575

git commit source code:
https://github.com/git/git/blob/b7bd9486b055c3f967a870311e704e3bb0654e4f/builtin/commit.c#L1478