### PR TITLE
allow pre-push commands to take arguments

### DIFF
--- a/index.js
+++ b/index.js
@@ -215,7 +215,7 @@ Hook.prototype.run = function runner() {
     // output colors resulting in script output that doesn't have any color.
     //
     
-    let cmd = process.platform=='win32' ? 'npm.cmd' : 'npm';
+    var cmd = process.platform=='win32' ? 'npm.cmd' : 'npm';
     spawn(cmd, ['run', '--silent'].concat(script.split(/\s+/)), {
       env: process.env,
       cwd: hooked.root,

--- a/index.js
+++ b/index.js
@@ -216,7 +216,7 @@ Hook.prototype.run = function runner() {
     //
     
     let cmd = process.platform=='win32' ? 'npm.cmd' : 'npm';
-    spawn(cmd, ['run', script, '--silent'], {
+    spawn(cmd, ['run', '--silent'].concat(script.split(/\s+/)), {
       env: process.env,
       cwd: hooked.root,
       stdio: [0, 1, 2]


### PR DESCRIPTION
allows inputs like so:
```json
{
  "scripts": {
    "test": "mocha-webpack"
  },
  "pre-push": [
    "test -- --interactive=false"
  ]
}
```