### PR TITLE
Fix error "Cannot find module" on Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -215,7 +215,7 @@ Hook.prototype.run = function runner() {
     // output colors resulting in script output that doesn't have any color.
     //
     
-    let cmd = process.platform=='win32' ? 'npm.cmd' : 'npm';
+    let cmd = process.platform=='win32' ? hooked.npm : 'npm';
     spawn(cmd, ['run', script, '--silent'], {
       env: process.env,
       cwd: hooked.root,


### PR DESCRIPTION
On Windows 10 in Termnial and SmartGit I got an error (below). I found that it is because in 218 line path to npm setted relative to current folder and ingored found npm path `hooked.npm`

```
node:internal/modules/cjs/loader:936
  throw err;
  ^

Error: Cannot find module 'C:\Users\InoY\Projects\lims-ui\node_modules\npm\bin\npm-cli.js'
    at Function.Module._resolveFilename (node:internal/modules/cjs/loader:933:15)
    at Function.Module._load (node:internal/modules/cjs/loader:778:27)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:79:12)
    at node:internal/main/run_main_module:17:47 {
  code: 'MODULE_NOT_FOUND',
  requireStack: []
}
node:internal/modules/cjs/loader:936
  throw err;
  ^

Error: Cannot find module 'C:\Users\InoY\Projects\lims-ui\node_modules\npm\bin\npm-cli.js'
    at Function.Module._resolveFilename (node:internal/modules/cjs/loader:933:15)
    at Function.Module._load (node:internal/modules/cjs/loader:778:27)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:79:12)
    at node:internal/main/run_main_module:17:47 {
  code: 'MODULE_NOT_FOUND',
  requireStack: []
}
```