### PR TITLE
Read stdin input from git, so that npm scripts don't see it

### DIFF
--- a/hook
+++ b/hook
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Capture the refs supplied by git on stdin, so as not to confuse our callees.
+REFS=`read`
+
 HAS_NODE=`which node 2> /dev/null || which nodejs 2> /dev/null || which iojs 2> /dev/null`
 
 #


### PR DESCRIPTION
Git supplies the push hook with information on stdin about the refs being
pushed. This can confuse the npm scripts being run.
